### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/transilvlad/mta-sts/security/code-scanning/1](https://github.com/transilvlad/mta-sts/security/code-scanning/1)

To fix the problem, we need to explicitly set the `permissions` block for the job or globally for the entire workflow. Since this workflow only checks out code and builds using Maven (without modifying the repository, opening issues, or making PRs), it only needs read access to repository contents.  
The best way to fix is to add a `permissions` block with `contents: read` at the workflow level (after the name and before jobs), which applies to all jobs unless overridden, or directly inside the job definition. As the workflow contains a single job, either location is suitable, but the workflow root is conventional for single-job CI workflows.

You only need to edit `.github/workflows/maven.yml`, adding these lines:
```yaml
permissions:
  contents: read
```
above `jobs:` on line 9.

No methods, imports, or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
